### PR TITLE
added Portland chapter to top nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,6 +264,7 @@
     <ul class="chapters">
       <li>London chapter</li>
       <li><a href="http://mirceageorgescu.github.io/beerclub/">Bucharest chapter</a></li>
+      <li><a href="http://taylor-l-beach.github.io/beerclub/">Portland chapter</a></li>
     </ul>
     <h2>rules</h2>
     <ol class="rules">


### PR DESCRIPTION
Noticed that link to Portland chapter is missing on London site
